### PR TITLE
feat: added sidecar support to work similar to initContainers

### DIFF
--- a/charts/common/templates/_pod.tpl
+++ b/charts/common/templates/_pod.tpl
@@ -30,7 +30,7 @@ spec:
   {{- range $container := $pod.containers }}
     {{- include "common.container" (list $top $container $pod) | nindent 4 }}
   {{- end }}
-  {{- range $container := $top.sidecards }}
+  {{- range $container := $top.sidecars }}
     {{- include "common.container" (list $top $container $pod) | nindent 4 }}
   {{- end }}
   {{- with $pod.nodeSelector }}


### PR DESCRIPTION
As a consumer of a ILF Helm chart I want to be able to add a set of custom sidecar container that is specific to my deployment without being forced to redefine the whole container list. This is so that I can use technologies like CloudSQL authentication proxy or other monitoring and troubleshooting tools that need to run in the same pod as my target container.

For example, in values.yaml a consumer can now add
```yaml
sidecars:
  - name: debugbox
    image:
      name: busybox
      tag: "latest"
      repository: "docker.io"
    command:
      - sleep
      - "3600"
    resources:
      requests:
        memory: 128Mi
        cpu: 200m
      limits:
        memory: 512Mi
        cpu: 400m
```