### PR TITLE
feat(common): incremental expansion of common library features

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -3,7 +3,7 @@ name: common
 description: Rafiki common helm chart for building k8s resources
 
 type: library
-version: 0.1.0
+version: 0.2.0
 
 maintainers:
   - name: golobitch

--- a/charts/common/templates/_container.yaml
+++ b/charts/common/templates/_container.yaml
@@ -12,6 +12,8 @@
   image: "{{ $container.image.repository }}/{{ $image.name | default $top.Chart.Name }}:{{ $container.image.tag | default "latest" }}"
   {{- else if $imageDigest}}
   image: "ghcr.io/interledger/{{ $image.name | default $top.Chart.Name }}@sha256:{{ $imageDigest }}"
+  {{- else if $top.Values.versionOverride }}
+  image: "ghcr.io/interledger/{{ $image.name | default $top.Chart.Name }}:{{ $top.Values.versionOverride }}"
   {{- else }}
   image: "ghcr.io/interledger/{{ $image.name | default $top.Chart.Name }}:{{ $top.Chart.AppVersion }}"
   {{- end }}

--- a/charts/common/templates/_pod.tpl
+++ b/charts/common/templates/_pod.tpl
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if $serviceAccount.create }}
+  {{- if $serviceAccount.name }}
   serviceAccountName: {{ include "common.serviceAccountName" (list $top $serviceAccount) }}
   {{- else }}
   automountServiceAccountToken: true

--- a/charts/common/templates/_service.yaml
+++ b/charts/common/templates/_service.yaml
@@ -10,6 +10,10 @@ kind: Service
 metadata:
   name: {{ printf "%s-%s" (include "common.fullname" $top) $service.name }}
   {{- include "common.metadata" (list $top) | nindent 2 }}
+  annotations:
+    {{- range $key, $value := $service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ $service.type }}
   ports: {{- toYaml $service.ports | nindent 4 }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -1,3 +1,5 @@
+versionOverride: null
+
 securityContext:
   capabilities:
     drop:


### PR DESCRIPTION
- Pod serviceAccountName should be set if the name is set, create is irrelevant
- Consumer can now define annotations for services
- Introduced concept versionOverride that allows the overriding of the ApplicationVersion. This allows us to run older versions of rafiki with newer versions of the chart.
- Bumped the version of the common chart