### PR TITLE
feat(interledger-app): set default env to dev

### DIFF
--- a/charts/interledger-app/backend/values.yaml
+++ b/charts/interledger-app/backend/values.yaml
@@ -18,7 +18,7 @@ database:
     password: "pacioli"
 
 config:
-  environment: sandbox
+  environment: dev
   log_level: "info"
   usd_ledger_id: "1"
   noop_equity_account_id: "00000000-0000-0000-0000-000000000000"

--- a/charts/interledger-app/frontend/values.yaml
+++ b/charts/interledger-app/frontend/values.yaml
@@ -43,7 +43,7 @@ config:
   cf_turnstile_site_key: "0000000000000000000000000000000000000000000000"
   cf_turnstile_secret_key: "0000000000000000000000000000000000000000000000"
 
-  environment: sandbox
+  environment: dev
 
 replicaCount: 1
 


### PR DESCRIPTION
`FYNBOS_ENV` as `sandbox` is not used anywhere at the moment. For the sandbox we should set the default value to `dev`.