### PR TITLE
fix(rafiki): corrected linkup of auth service api url

### DIFF
--- a/charts/rafiki/values.yaml
+++ b/charts/rafiki/values.yaml
@@ -568,7 +568,9 @@ configMaps:
       - key: OPERATOR_TENANT_ID
         valueRef: config.backend.tenancy.tenant_id
       - key: ADMIN_SIGNATURE_VERSION
-        valueRef: config.backend.admin.signatureVersion        
+        valueRef: config.backend.admin.signatureVersion      
+      - key: AUTH_SERVICE_API_URL
+        valueRef: config.backend.auth.serviceApiUrl
       # See templates/configMap.backend.yaml on how we patch WALLET_ADDRESS_URL
       # to automatically have the /.well-known/pay suffix
 


### PR DESCRIPTION
This pull request adds a new configuration option to the `configMaps` section in `charts/rafiki/values.yaml`, allowing the backend to reference the authentication service API URL.

Configuration enhancements:

* Added a new `AUTH_SERVICE_API_URL` key to `configMaps`, referencing `config.backend.auth.serviceApiUrl`.