### PR TITLE
fix(rafiki): increased timeout for rafiki readiness probe

### DIFF
--- a/charts/rafiki/values.yaml
+++ b/charts/rafiki/values.yaml
@@ -396,7 +396,7 @@ deployments:
         path: /healthz
         port: 3000
     readinessProbe:
-      # Makes initial longer to accomodate migrations from v1 to v2
+      # Makes initial longer to accommodate migrations from v1 to v2
       initialDelaySeconds: 30
       periodSeconds: 5
       timeoutSeconds: 1


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment configuration to improve readiness during migrations. The initial delay for the readiness probe has been increased to allow more time for migrations from v1 to v2.

* Increased `initialDelaySeconds` for the readiness probe from 10 to 30 seconds in `charts/rafiki/values.yaml` to better accommodate migration processes.