### PR TITLE
fix(rafiki-services): rafiki-cards and pos configuration fixes

### DIFF
--- a/charts/rafiki-cards/values.yaml
+++ b/charts/rafiki-cards/values.yaml
@@ -26,6 +26,9 @@ config:
       # secretKeyRef:
       #   key: tenant.secret
 
+  redis:
+    url: "redis://my-redis"
+
   trust_proxy: ""
 
 services:
@@ -94,6 +97,11 @@ deployments:
         configMapKeyRef:
           name: '{{ include "common.fullname" . }}-config'
           key: trust_proxy
+    - name: REDIS_URL
+      valueFrom:
+        configMapKeyRef:
+          name: '{{ include "common.fullname" . }}-config'
+          key: redis.url
     
     livenessProbe:
       httpGet:

--- a/charts/rafiki-point-of-sale/values.yaml
+++ b/charts/rafiki-point-of-sale/values.yaml
@@ -16,14 +16,14 @@ config:
   ase:
     graphqlUrl: "http://my-ase:3001/graphql"
 
-  openpayments:
+  backend:
     webhook:
       signatureVersion: "1"
       secret:
         value: "REPLACE-WITH-ACTUAL-SECRET"
         # Or reference an existing Kubernetes secret like this:
         # secretKeyRef:
-        #   key: openpayments.webhook.secret
+        #   key: backend.webhook.secret
 
   tenant:
     id: "00000000-0000-0000-0000-000000000000"
@@ -91,12 +91,12 @@ deployments:
       valueFrom:
         secretKeyRef:
           name: '{{ include "common.fullname" . }}-secrets'
-          key: openpayments.webhook.secret
+          key: backend.webhook.secret
     - name: WEBHOOK_SIGNATURE_VERSION
       valueFrom:
         configMapKeyRef:
           name: '{{ include "common.fullname" . }}-config'
-          key: openpayments.webhook.signatureVersion
+          key: backend.webhook.signatureVersion
     - name: TRUST_PROXY
       valueFrom:
         configMapKeyRef:
@@ -119,8 +119,8 @@ configMaps:
         valueRef: config.log_level
       - key: ase.graphqlUrl
         valueRef: config.ase.graphqlUrl
-      - key: openpayments.webhook.signatureVersion
-        valueRef: config.openpayments.webhook.signatureVersion
+      - key: backend.webhook.signatureVersion
+        valueRef: config.backend.webhook.signatureVersion
       - key: tenant.id
         valueRef: config.tenant.id
       - key: tenant.signatureVersion
@@ -136,5 +136,5 @@ secretsMaps:
     contentMap:
       - key: tenant.secret
         valueRef: config.tenant.secret.value
-      - key: openpayments.webhook.secret
-        valueRef: config.openpayments.webhook.secret.value
+      - key: backend.webhook.secret
+        valueRef: config.backend.webhook.secret.value


### PR DESCRIPTION
This pull request updates configuration management for both the `rafiki-cards` and `rafiki-point-of-sale` Helm charts. The main changes are the addition of Redis configuration to `rafiki-cards` and the renaming of the `openpayments` configuration section to `backend` in `rafiki-point-of-sale`, ensuring consistent naming and environment variable mapping for webhook settings.

**Redis configuration addition (rafiki-cards):**
* Added a new `redis.url` setting under the `config` section in `charts/rafiki-cards/values.yaml` to specify the Redis connection URL.
* Updated the deployment environment variable mapping to include `REDIS_URL`, sourcing its value from the config map.

**Webhook configuration renaming (rafiki-point-of-sale):**
* Renamed the `openpayments` configuration section to `backend` in `charts/rafiki-point-of-sale/values.yaml`, affecting webhook signature version and secret settings.
* Updated environment variable mappings in the deployment to use the new `backend` keys for webhook secret and signature version.

**Config and secret map updates (rafiki-point-of-sale):**
* Changed config map key references from `openpayments.webhook.signatureVersion` to `backend.webhook.signatureVersion`.
* Changed secrets map key references from `openpayments.webhook.secret` to `backend.webhook.secret`.