### PR TITLE
feat(ilf-interledger-app): support for app v1.9.0

### DIFF
--- a/charts/interledger-app/admin/Chart.yaml
+++ b/charts/interledger-app/admin/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.1.12
-appVersion: v1.7.9
+appVersion: v1.9.0
 
 dependencies:
   - name: common

--- a/charts/interledger-app/backend/Chart.yaml
+++ b/charts/interledger-app/backend/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.7.13
-appVersion: v1.7.9
+appVersion: v1.9.0
 
 dependencies:
   - name: common

--- a/charts/interledger-app/backend/tests/deployment.server.configmaps_test.yaml
+++ b/charts/interledger-app/backend/tests/deployment.server.configmaps_test.yaml
@@ -136,3 +136,71 @@ tests:
       - equal:
           path: data.GATEHUB_ORGANIZATION_ID
           value: "SOME ORG ID"
+  - it: 'should contain EMAIL_ENABLED=true by default'
+    asserts:
+      - equal:
+          path: data.EMAIL_ENABLED
+          value: "true"
+  - it: 'should allow disabling email via EMAIL_ENABLED'
+    set:
+      config:
+        email:
+          enabled: "false"
+    asserts:
+      - equal:
+          path: data.EMAIL_ENABLED
+          value: "false"
+  - it: 'should contain SENDGRID_FROM_NAME in data'
+    set:
+      config:
+        sendgrid:
+          from_name: "Interledger Wallet"
+    asserts:
+      - equal:
+          path: data.SENDGRID_FROM_NAME
+          value: "Interledger Wallet"
+  - it: 'should contain SENDGRID_FROM_EMAIL in data'
+    set:
+      config:
+        sendgrid:
+          from_email: "support@interledger.app"
+    asserts:
+      - equal:
+          path: data.SENDGRID_FROM_EMAIL
+          value: "support@interledger.app"
+  - it: 'should contain SENDGRID_ONE_TEMPLATE_ID in data'
+    set:
+      config:
+        sendgrid:
+          one_template_id: "d-12030774d225454ea91720034b9adb97"
+    asserts:
+      - equal:
+          path: data.SENDGRID_ONE_TEMPLATE_ID
+          value: "d-12030774d225454ea91720034b9adb97"
+  - it: 'should contain PERSONA_BASE_URL with default value'
+    asserts:
+      - equal:
+          path: data.PERSONA_BASE_URL
+          value: "https://api.withpersona.com/api/v1/"
+  - it: 'should allow overriding PERSONA_BASE_URL'
+    set:
+      config:
+        persona:
+          base_url: "http://mockxago:8080/v1/"
+    asserts:
+      - equal:
+          path: data.PERSONA_BASE_URL
+          value: "http://mockxago:8080/v1/"
+  - it: 'should contain empty SIGNUP_AGREEMENT_IDS by default'
+    asserts:
+      - equal:
+          path: data.SIGNUP_AGREEMENT_IDS
+          value: ""
+  - it: 'should contain SIGNUP_AGREEMENT_IDS when set'
+    set:
+      config:
+        signup_agreement_ids: "privacy_policy-0.0.0,terms_of_service-0.0.0"
+    asserts:
+      - equal:
+          path: data.SIGNUP_AGREEMENT_IDS
+          value: "privacy_policy-0.0.0,terms_of_service-0.0.0"

--- a/charts/interledger-app/backend/values.yaml
+++ b/charts/interledger-app/backend/values.yaml
@@ -170,8 +170,19 @@ config:
     webhook_secret_ref: "chimoneyWebhookSecret"
     token_ref: "chimoneyToken"
 
+  email:
+    # Set to "false" to disable all outgoing emails. Defaults to enabled.
+    # When disabled, SendGrid env vars are not required.
+    enabled: "true"
+
   sendgrid:
     api_key_ref: "sendgridApiKey"
+    # Display name for outgoing emails (e.g. "Interledger Wallet").
+    from_name: ""
+    # Sender email address for outgoing emails.
+    from_email: ""
+    # SendGrid Dynamic Template ID used by backend transactional emails.
+    one_template_id: ""
 
 
   pusher:
@@ -191,6 +202,8 @@ config:
     token_ref: "basisTheoryToken"
 
   persona:
+    # Persona API base URL override. Default when unset: https://api.withpersona.com/api/v1/
+    base_url: "https://api.withpersona.com/api/v1/"
     token_ref: "personaToken"
     webhook_token_ref: "personaWebhookToken"
 
@@ -227,6 +240,10 @@ config:
     public_key_jwk_ref: "ptiPublicKeyJwk"
     # Secret key containing PTI client UUID for API/webhook validation.
     client_id_ref: "ptiClientID"
+
+  # Comma-separated list of agreement IDs that must be signed during signup
+  # (e.g. "privacy_policy-0.0.0,terms_of_service-0.0.0"). Leave empty to skip.
+  signup_agreement_ids: ""
 
   redis_url_ref: "redisURL"
 
@@ -895,3 +912,15 @@ configMaps:
         valueRef: config.pti.forms_url
       - key: PORT
         valueRef: config.port
+      - key: EMAIL_ENABLED
+        valueRef: config.email.enabled
+      - key: SENDGRID_FROM_NAME
+        valueRef: config.sendgrid.from_name
+      - key: SENDGRID_FROM_EMAIL
+        valueRef: config.sendgrid.from_email
+      - key: SENDGRID_ONE_TEMPLATE_ID
+        valueRef: config.sendgrid.one_template_id
+      - key: PERSONA_BASE_URL
+        valueRef: config.persona.base_url
+      - key: SIGNUP_AGREEMENT_IDS
+        valueRef: config.signup_agreement_ids

--- a/charts/interledger-app/frontend/Chart.yaml
+++ b/charts/interledger-app/frontend/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.3.10
-appVersion: v1.7.9
+appVersion: v1.9.0
 
 dependencies:
   - name: common


### PR DESCRIPTION
This pull request updates the Helm charts for the Interledger app, introducing new configuration options for email, Persona API, and signup agreements, as well as updating the app version across all components. The changes improve flexibility and control over backend configuration, especially for email and user onboarding flows.

**Chart version updates:**

* Bumped `appVersion` from `v1.7.9` to `v1.9.0` in `admin`, `backend`, and `frontend` Helm charts, ensuring all components reference the latest application version. [[1]](diffhunk://#diff-3a65c3423b059a367b27f5733b480320bc6bd5e3dd0b33759d1b784cd54192c7L8-R8) [[2]](diffhunk://#diff-d3cce31afa93e703200c096cbcc14123eba5244817d281a0e76b94343753fa80L8-R8) [[3]](diffhunk://#diff-8009f5aed8ab43990f211224ec19ad90d109e683c46b9c2ebe2eb15b097be60bL8-R8)

**Backend configuration enhancements:**

* Added new configuration options in `values.yaml` for email (enable/disable, SendGrid sender details, template ID), Persona API base URL override, and required signup agreement IDs. [[1]](diffhunk://#diff-5c1648ff80208a48c7b95ee2f15c0360751233734f51d486b76fd12983a75ab3R173-R185) [[2]](diffhunk://#diff-5c1648ff80208a48c7b95ee2f15c0360751233734f51d486b76fd12983a75ab3R205-R206) [[3]](diffhunk://#diff-5c1648ff80208a48c7b95ee2f15c0360751233734f51d486b76fd12983a75ab3R244-R247)
* Updated backend config map to expose new environment variables: `EMAIL_ENABLED`, `SENDGRID_FROM_NAME`, `SENDGRID_FROM_EMAIL`, `SENDGRID_ONE_TEMPLATE_ID`, `PERSONA_BASE_URL`, and `SIGNUP_AGREEMENT_IDS`.

**Testing improvements:**

* Expanded deployment config map tests to verify new email, Persona, and signup agreement environment variables, including default values and override scenarios.