### PR TITLE
feat: app version upgrade to v1.10.0

### DIFF
--- a/charts/interledger-app/admin/Chart.yaml
+++ b/charts/interledger-app/admin/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.2.1
-appVersion: v1.9.1
+appVersion: v1.10.0
 
 dependencies:
   - name: common

--- a/charts/interledger-app/backend/Chart.yaml
+++ b/charts/interledger-app/backend/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.8.1
-appVersion: v1.9.1
+appVersion: v1.10.0
 
 dependencies:
   - name: common

--- a/charts/interledger-app/backend/values.yaml
+++ b/charts/interledger-app/backend/values.yaml
@@ -98,6 +98,20 @@ config:
       auth_url: "http://rafiki-auth:3003/graphql"
       backend_url: "http://rafiki-backend:3001/graphql"
 
+    # Rafiki multi-tenancy configuration (required as of Rafiki v2.3.0-beta).
+    # These values are used by the adminSigningRoundTripper to authenticate
+    # and sign outbound requests to the Rafiki admin API.
+
+    # Secret key containing the Rafiki operator tenant UUID.
+    # Sent as the "tenant-id" header on every Rafiki admin API request.
+    operator_tenant_id_ref: "rafikiOperatorTenantID"
+    # Secret key containing the shared secret used to sign Rafiki admin API requests.
+    # Signatures use HMAC-SHA256 over the timestamp and canonical JSON request body.
+    admin_api_secret_ref: "rafikiAdminAPISecret"
+    # Secret key containing the signature scheme version (e.g. "1").
+    # Included in the "signature" header as the version component.
+    signature_version_ref: "rafikiSignatureVersion"
+
   temporal:
     url: "temporal:7233"
 
@@ -495,6 +509,22 @@ server:
           secretKeyRef:
             name: '{{ include "common.fullname" . }}'
             key: "{{ .Values.config.redis_url_ref }}"
+    # Rafiki multi-tenancy secrets — required as of Rafiki v2.3.0-beta.
+    -  name: OPERATOR_TENANT_ID
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.operator_tenant_id_ref }}"
+    -  name: ADMIN_API_SECRET
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.admin_api_secret_ref }}"
+    -  name: SIGNATURE_VERSION
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.signature_version_ref }}"
   resources:
     requests:
       memory: 128Mi
@@ -792,6 +822,22 @@ worker:
           secretKeyRef:
             name: '{{ include "common.fullname" . }}'
             key: "{{ .Values.config.redis_url_ref }}"
+    # Rafiki multi-tenancy secrets — required as of Rafiki v2.3.0-beta.
+    -  name: OPERATOR_TENANT_ID
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.operator_tenant_id_ref }}"
+    -  name: ADMIN_API_SECRET
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.admin_api_secret_ref }}"
+    -  name: SIGNATURE_VERSION
+       valueFrom:
+          secretKeyRef:
+            name: '{{ include "common.fullname" . }}'
+            key: "{{ .Values.config.rafiki.signature_version_ref }}"
   resources:
     requests:
       memory: 128Mi

--- a/charts/interledger-app/frontend/Chart.yaml
+++ b/charts/interledger-app/frontend/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/interledger/interledger-app
 
 type: application
 version: 2.4.1
-appVersion: v1.9.1
+appVersion: v1.10.0
 
 dependencies:
   - name: common


### PR DESCRIPTION
This pull request updates the Interledger app Helm charts to support Rafiki v2.3.0-beta, which introduces required multi-tenancy configuration. It also bumps the `appVersion` for all chart components to v1.10.0. The main changes involve adding new configuration values and Kubernetes secrets to support Rafiki's multi-tenant admin API authentication.

Key changes:

**Rafiki multi-tenancy support:**

* Added new configuration options under `rafiki` in `backend/values.yaml` for multi-tenancy secrets: `operator_tenant_id_ref`, `admin_api_secret_ref`, and `signature_version_ref`, which are required for authenticating and signing requests to the Rafiki admin API.
* Updated the `server` and `worker` environment variable sections in `backend/values.yaml` to inject the new multi-tenancy secrets as environment variables (`OPERATOR_TENANT_ID`, `ADMIN_API_SECRET`, `SIGNATURE_VERSION`) from Kubernetes secrets. [[1]](diffhunk://#diff-5c1648ff80208a48c7b95ee2f15c0360751233734f51d486b76fd12983a75ab3R512-R527) [[2]](diffhunk://#diff-5c1648ff80208a48c7b95ee2f15c0360751233734f51d486b76fd12983a75ab3R825-R840)

**Chart version updates:**

* Bumped `appVersion` from v1.9.1 to v1.10.0 in `admin/Chart.yaml`, `backend/Chart.yaml`, and `frontend/Chart.yaml` to reflect compatibility with the new Rafiki version. [[1]](diffhunk://#diff-3a65c3423b059a367b27f5733b480320bc6bd5e3dd0b33759d1b784cd54192c7L8-R8) [[2]](diffhunk://#diff-d3cce31afa93e703200c096cbcc14123eba5244817d281a0e76b94343753fa80L8-R8) [[3]](diffhunk://#diff-8009f5aed8ab43990f211224ec19ad90d109e683c46b9c2ebe2eb15b097be60bL8-R8)