### PR TITLE
feat(interledger-app): protea can now configure BACKEND_HTTP_URL using 'config.backend.http.url'

### DIFF
--- a/charts/interledger-app/frontend/values.yaml
+++ b/charts/interledger-app/frontend/values.yaml
@@ -14,6 +14,8 @@ config:
   backend:
     grpc:
       url: "http://wallet-backend-service:8443"
+    http:
+      url: "http://wallet-backend-service:3000"  
 
   redis:
     url_ref: redisURL
@@ -200,3 +202,5 @@ configMaps:
         valueRef: config.pti.sdk_url
       - key: PTI_FORMS_URL
         valueRef: config.pti.forms_url
+      - key: BACKEND_HTTP_URL
+        valueRef: config.backend.http.url

--- a/charts/interledger-app/frontend/values.yaml
+++ b/charts/interledger-app/frontend/values.yaml
@@ -15,7 +15,7 @@ config:
     grpc:
       url: "http://wallet-backend-service:8443"
     http:
-      url: "http://wallet-backend-service:3000"  
+      url: "http://wallet-backend-service:3000"
 
   redis:
     url_ref: redisURL


### PR DESCRIPTION
This pull request updates the frontend configuration for the Interledger app to add support for accessing the backend service over HTTP, in addition to the existing gRPC configuration. The changes ensure that the HTTP backend URL is available both in the configuration and as an environment variable for the frontend.

Configuration updates:

* Added a new `http` section under `backend` in `frontend/values.yaml`, specifying the HTTP URL for the backend service (`config.backend.http.url`).

Environment variable updates:

* Added a new config map entry to set the `BACKEND_HTTP_URL` environment variable in the frontend deployment, referencing the new HTTP backend URL configuration (`config.backend.http.url`).