### PR TITLE
fix(testnet-wallet): accessKeys should not be secrets

### DIFF
--- a/charts/testnet-wallet/values.yaml
+++ b/charts/testnet-wallet/values.yaml
@@ -100,19 +100,13 @@ config:
 
     gatehub:
       env: "sandbox"
-      accessKey:
-        # value: ""
-          secretKeyRef:
-            key: "gatehub.accessKey"
+      accessKey: "00000000-0000-0000-0000-000000000000"
       secretKey:
         # value: ""
         secretKeyRef:
           key: "gatehub.secretKey"
       apiBaseUrl: "https://api.sandbox.gatehub.net"
-      accessSepaKey:
-        # value: ""
-        secretKeyRef:
-          key: "gatehub.accessSepaKey"
+      accessSepaKey: "00000000-0000-0000-0000-000000000000"
       secretSepaKey:
         # value: ""
         secretKeyRef:


### PR DESCRIPTION
In a previous iteration we made the mistake of treating accesKeys as secrets. They should be configs, this aligns with existing deployment configuration.