### PR TITLE
fix(testnet-wallet): chart will now correctly set BACKEND_INTERNAL_URL

### DIFF
--- a/charts/testnet-wallet/tests/deployment.backend_test.yaml
+++ b/charts/testnet-wallet/tests/deployment.backend_test.yaml
@@ -58,3 +58,12 @@ tests:
       - equal:
           path: data.GATEHUB_SEPA_ACCESS_KEY
           value: test-sepa-access-key
+  - it: 'should add BACKEND_INTERNAL_URL with correct service'
+    template: deployment.backend.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: BACKEND_INTERNAL_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: 'http://test-testnet-wallet-backend-service:4003'

--- a/charts/testnet-wallet/values.yaml
+++ b/charts/testnet-wallet/values.yaml
@@ -169,9 +169,9 @@ deployments:
           name: '{{ include "common.fullname" . }}-backend'
 
     env:
-      # Backend internal 
+      # Backend internal URL (in-cluster)
       - name: BACKEND_INTERNAL_URL
-        value: 'http://{{ include "common.fullname" . }}-backend-service:4003'
+        value: 'http://{{ include "common.fullname" . }}-{{ .Values.services.backend.name }}:{{ (index .Values.services.backend.ports 0).port }}'
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:

--- a/charts/testnet-wallet/values.yaml
+++ b/charts/testnet-wallet/values.yaml
@@ -169,6 +169,9 @@ deployments:
           name: '{{ include "common.fullname" . }}-backend'
 
     env:
+      # Backend internal 
+      - name: BACKEND_INTERNAL_URL
+        value: 'http://{{ include "common.fullname" . }}-backend-service:4003'
       - name: DATABASE_URL
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
The chart was not setting `BACKEND_INTERNAL_URL` which I believe is the root of the problems that we have been experiencing on Tuesday.

---

## Auto generated

This pull request adds a new environment variable, `BACKEND_INTERNAL_URL`, to the backend deployment configuration for the testnet wallet. It also introduces a corresponding test to ensure the environment variable is correctly set in the deployment.

Environment variable addition:

* Added `BACKEND_INTERNAL_URL` to the backend deployment environment variables in `values.yaml`, setting its value to the backend service's internal URL.

Testing improvements:

* Added a test case in `deployment.backend_test.yaml` to verify that `BACKEND_INTERNAL_URL` is correctly set in the deployment manifest.